### PR TITLE
Disable Unwanted HTTP Methods

### DIFF
--- a/vms/science-gateway/nginx.conf
+++ b/vms/science-gateway/nginx.conf
@@ -32,12 +32,18 @@ http {
 
     server {
         listen 80;
+        if ($request_method !~ ^(GET|HEAD|POST)$ ) {
+            return 444;
+        }
         server_name science-gateway.unidata.ucar.edu;
         return 301 https://$host$request_uri;
     }
 
     server { # This new server will watch for traffic on 443
         listen              443 ssl;
+        if ($request_method !~ ^(GET|HEAD|POST)$ ) {
+            return 444;
+        }
         server_name         science-gateway.unidata.ucar.edu;
         ssl_certificate     /etc/nginx/science-gateway.unidata.ucar.edu.crt;
         ssl_certificate_key /etc/nginx/science-gateway.unidata.ucar.edu.key;


### PR DESCRIPTION
@oxelson a [Google search](https://www.google.com/search?q=nginx+Disable+Unwanted+HTTP+Methods&oq=nginx+Disable+Unwanted+HTTP+Methods) reveals a disappointing lack of clarity on this issue. (See the thread on the Bjørn Johansen blog.) I also understand that [444](https://httpstatuses.com/444) is preferable over [405](https://httpstatuses.com/405). Nevertheless, I think this will work. 