### PR TITLE
obscure server information

### DIFF
--- a/vms/science-gateway/nginx.conf
+++ b/vms/science-gateway/nginx.conf
@@ -23,6 +23,7 @@ http {
 
     etag            off;
     sendfile        off;
+    server_tokens   off;
     #tcp_nopush     on;
 
     keepalive_timeout  65;


### PR DESCRIPTION
ping @oxelson 

Before:

```
▶ curl -I https://science-gateway.unidata.ucar.edu
HTTP/1.1 200 OK
Server: nginx/1.17.4
Date: Fri, 01 Nov 2019 20:44:38 GMT
Content-Type: text/html
Content-Length: 45248
Last-Modified: Wed, 30 Oct 2019 23:46:08 GMT
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
Accept-Ranges: bytes
```

After:

```
▶ curl -I https://science-gateway.unidata.ucar.edu
HTTP/1.1 200 OK
Server: nginx
Date: Fri, 01 Nov 2019 21:12:51 GMT
Content-Type: text/html
Content-Length: 45248
Last-Modified: Wed, 30 Oct 2019 23:46:08 GMT
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
Accept-Ranges: bytes
```