### PR TITLE
xss protection

### DIFF
--- a/vms/science-gateway/nginx.conf
+++ b/vms/science-gateway/nginx.conf
@@ -38,6 +38,8 @@ http {
             return 444;
         }
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-XSS-Protection "1; mode=block";
+
         server_name science-gateway.unidata.ucar.edu;
         return 301 https://$host$request_uri;
     }
@@ -48,6 +50,8 @@ http {
             return 444;
         }
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-XSS-Protection "1; mode=block";
+
         server_name         science-gateway.unidata.ucar.edu;
         ssl_certificate     /etc/nginx/science-gateway.unidata.ucar.edu.crt;
         ssl_certificate_key /etc/nginx/science-gateway.unidata.ucar.edu.key;


### PR DESCRIPTION
ping @oxelson 

Before

```
▶ curl -I https://science-gateway.unidata.ucar.edu
HTTP/1.1 200 OK
Server: nginx
Date: Fri, 01 Nov 2019 21:57:09 GMT
Content-Type: text/html
Content-Length: 45248
Last-Modified: Wed, 30 Oct 2019 23:46:08 GMT
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
Accept-Ranges: bytes
```

After:

```
▶ curl -I https://science-gateway.unidata.ucar.edu
HTTP/1.1 200 OK
Server: nginx
Date: Fri, 01 Nov 2019 21:59:06 GMT
Content-Type: text/html
Content-Length: 45248
Last-Modified: Wed, 30 Oct 2019 23:46:08 GMT
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
Accept-Ranges: bytes
```